### PR TITLE
Update name of binary to bearcatter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ use `go build` to make a binary
 Start the server with `--help` to see the options
 
 ```
-./server --help
+./bearcatter --help
 ```
 
 ### License


### PR DESCRIPTION
It looks like in Bearcatter#14, the project was re-organized to compile to a binary named `bearcatter`, rather than `server`, so I just updated the name here.

I just downloaded and compiled this a moment ago, so if I'm doing something wrong and the docs are correct please feel free to close.

Great work on this project so far, I'm looking forward to trying it out!